### PR TITLE
Removing deprecated material/colour; using RAL 9007 instead

### DIFF
--- a/staubli_rx160_support/urdf/rx160_macro.xacro
+++ b/staubli_rx160_support/urdf/rx160_macro.xacro
@@ -142,7 +142,7 @@
         <geometry>
           <mesh filename="package://staubli_rx160_support/meshes/rx160/visual/link_6.stl"/>
         </geometry>
-        <xacro:material_staubli_ral_traffic_grey_b />
+        <xacro:material_staubli_ral_grey_aluminium />
       </visual>
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0"/>

--- a/staubli_rx160_support/urdf/rx160l_macro.xacro
+++ b/staubli_rx160_support/urdf/rx160l_macro.xacro
@@ -142,7 +142,7 @@
         <geometry>
           <mesh filename="package://staubli_rx160_support/meshes/rx160/visual/link_6.stl"/>
         </geometry>
-        <xacro:material_staubli_ral_traffic_grey_b />
+        <xacro:material_staubli_ral_grey_aluminium />
       </visual>
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0"/>


### PR DESCRIPTION
The deprecated colour was introduced in ros-industrial/staubli#15, so I reckon we can just update the URDFs to use the up-to-date colours and materials.

I would also remove the `material_staubli_ral_traffic_grey_b` and `material_staubli_ral_zinc_yellow` (along with their respective colours). Given that ros-industrial/staubli#15 was merged yesterday, almost certainly no one else is using those definitions.

What do you reckon?
